### PR TITLE
First pass to get Rails 7 and Ruby 3 working

### DIFF
--- a/lib/state_machine/integrations/active_model.rb
+++ b/lib/state_machine/integrations/active_model.rb
@@ -382,7 +382,7 @@ module StateMachine
           end
           
           default_options = default_error_message_options(object, attribute, message)
-          object.errors.add(attribute, message, options.merge(default_options))
+          object.errors.add(attribute, message, **options.merge(default_options))
         end
       end
       

--- a/lib/state_machine/integrations/active_record.rb
+++ b/lib/state_machine/integrations/active_record.rb
@@ -479,11 +479,11 @@ module StateMachine
         def define_action_hook
           if action_hook == :save
             define_helper :instance, <<-end_eval, __FILE__, __LINE__ + 1
-              def save(*)
+              def save(**opts)
                 self.class.state_machine(#{name.inspect}).send(:around_save, self) { super }
               end
-              
-              def save!(*)
+
+              def save!(**opts)
                 self.class.state_machine(#{name.inspect}).send(:around_save, self) { super } || raise(ActiveRecord::RecordInvalid.new(self))
               end
               

--- a/lib/state_machine/integrations/base.rb
+++ b/lib/state_machine/integrations/base.rb
@@ -78,7 +78,7 @@ module StateMachine
         # support i18n.
         def locale_path
           path = "#{File.dirname(__FILE__)}/#{integration_name}/locale.rb"
-          path if File.exists?(path)
+          path if File.exist?(path)
         end
         
         # Extends the given object with any version overrides that are currently

--- a/test/unit/machine_test.rb
+++ b/test/unit/machine_test.rb
@@ -3229,26 +3229,26 @@ begin
     
     def test_should_save_file_with_class_name_by_default
       @machine.draw
-      assert File.exists?("./#{@klass.name}_state.png")
+      assert File.exist?("./#{@klass.name}_state.png")
     end
     
     def test_should_allow_base_name_to_be_customized
       name = "machine_#{rand(1000000)}"
       @machine.draw(:name => name)
       @path = "./#{name}.png"
-      assert File.exists?(@path)
+      assert File.exist?(@path)
     end
     
     def test_should_allow_format_to_be_customized
       @machine.draw(:format => 'jpg')
       @path = "./#{@klass.name}_state.jpg"
-      assert File.exists?(@path)
+      assert File.exist?(@path)
     end
     
     def test_should_allow_path_to_be_customized
       @machine.draw(:path => "#{File.dirname(__FILE__)}/")
       @path = "#{File.dirname(__FILE__)}/#{@klass.name}_state.png"
-      assert File.exists?(@path)
+      assert File.exist?(@path)
     end
     
     def test_should_allow_orientation_to_be_landscape


### PR DESCRIPTION
AR changed syntax for `save` and `save!` slightly, this adjusts to match.
File.exists? deprecated in favour of File.exist?
AR validation syntax also changed slightly.